### PR TITLE
fix(ci) Use rust-build.action@v1.4.0 for now

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Compile and release
         # https://github.com/rust-build/rust-build.action/issues/62
-        uses: rust-build/rust-build.action@1.4.0
+        uses: rust-build/rust-build.action@v1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}


### PR DESCRIPTION
https://github.com/rust-build/rust-build.action/issues/62

follow-up to https://github.com/joar/unmillis/pull/5, which used the wrong tag name.